### PR TITLE
Use `Hyperf\Context\ApplicationContext` instead of `Hyperf\Utils\Appl…

### DIFF
--- a/src/Commands/DumpServerCommand.php
+++ b/src/Commands/DumpServerCommand.php
@@ -8,7 +8,7 @@ use Hyperf\Command\Command;
 use Hyperf\Contract\ConfigInterface;
 use Hyperf\Contract\StdoutLoggerInterface;
 use Hyperf\Di\Container;
-use Hyperf\Utils\ApplicationContext;
+use Hyperf\Context\ApplicationContext;
 use InvalidArgumentException;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\VarDumper\Cloner\Data;

--- a/src/Listeners/DumpServerListener.php
+++ b/src/Listeners/DumpServerListener.php
@@ -17,6 +17,7 @@ use Symfony\Component\VarDumper\Dumper\ContextProvider\SourceContextProvider;
 use Symfony\Component\VarDumper\Server\Connection;
 use Symfony\Component\VarDumper\Server\DumpServer;
 use Symfony\Component\VarDumper\VarDumper;
+use Hyperf\Context\ApplicationContext;
 
 class DumpServerListener implements ListenerInterface
 {
@@ -34,7 +35,7 @@ class DumpServerListener implements ListenerInterface
     public function process(object $event): void
     {
         /** @var Container $container */
-        $container = \Hyperf\Utils\ApplicationContext::getContainer();
+        $container = ApplicationContext::getContainer();
         $config = $container->get(ConfigInterface::class);
         $host = $config->get('dump-server.host', 'tcp://127.0.0.1:9912');
         $container->set(DumpServer::class, function () use ($host) {


### PR DESCRIPTION
Since [v3.0.16](https://github.com/hyperf/hyperf/blob/master/CHANGELOG-3.0.md#v3016---2023-04-12), hyperf uses `Hyperf\Context\ApplicationContext`